### PR TITLE
Fixes directoy path

### DIFF
--- a/sources/admin-guide/installation/ubuntu.md
+++ b/sources/admin-guide/installation/ubuntu.md
@@ -25,7 +25,7 @@ Use the .deb installation to perform a base chroot installation with following G
 
 <code> # service gluu-server login </code> 
 
-<code> # cd /install/community-edition-setup/ </code>
+<code> # cd /install/community-edition-setup-master/ </code>
 
 <code> ./setup.py </code>
 


### PR DESCRIPTION
The current Ubuntu installation path is wrong. After `sudo service gluu-server login`  the available path is `/install/community-edition-setup-master`